### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ cython_debug/
 # env
 .env
 .env.local
+
+.DS_Store


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds `.DS_Store` to the `.gitignore` file in the triangular arbitrage repository. The change is a simple one-line addition that prevents macOS system files from being tracked in version control. `.DS_Store` files are automatically generated by macOS Finder to store folder metadata and display preferences, and they serve no functional purpose in the codebase.

This modification aligns with standard best practices for Python projects and follows the existing structure of the `.gitignore` file. The repository already has comprehensive ignore patterns for various development artifacts, testing files, and system-specific files, so this addition maintains consistency with the existing approach to version control hygiene. The change is particularly relevant for this project since it's a Python-based triangular arbitrage detection system that may be developed across different operating systems.

## Important Files Changed

<details>
<summary>Files Changed (1)</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.gitignore` | 5/5 | Added `.DS_Store` entry to prevent macOS system files from being tracked |

</details>

## Confidence score: 5/5

- This PR is extremely safe to merge with no risk of breaking functionality
- Score reflects a standard, best-practice change that only affects version control behavior
- No files require special attention as this is a trivial gitignore update

<!-- /greptile_comment -->